### PR TITLE
Case duplicado en colorear_nota

### DIFF
--- a/rac.html
+++ b/rac.html
@@ -94,7 +94,6 @@
               case "C+":
               case "SB":
               case "NO":
-              case "A":
               case "AP":
               case "M":
                   color='green';


### PR DESCRIPTION
case "A" está duplicado en la función colorear_nota. Se ha eliminado uno de ellos.